### PR TITLE
Update "composer/installers" required version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,6 @@
   },
   "require": {
     "php": ">=5.4.0",
-    "composer/installers": "~1.0.12"
+    "composer/installers": "^1.4"
   }
 }


### PR DESCRIPTION
When using with roots/bedrock, this plugin was stuck requiring an out of date version of composer/installers. Update brings it in line with latest bedrock and fixes the "roots/wp-h5bp-htaccess 2.0.1 requires composer/installers ~1.0.12" error.